### PR TITLE
Remove heading from body text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Data Science Basics
 
-#### Welcome to the Git repository for Data Science Basics. This information has been developed for Chemical Engineering students both under and postgraduate. The content is aimed at making data visualization, munging, interpreting and reporting as easy as Py-thon.
+Welcome to the Git repository for Data Science Basics. This information has been developed for Chemical Engineering students both under and postgraduate. The content is aimed at making data visualization, munging, interpreting and reporting as easy as Py-thon.
 
 * [Basic Plotting](https://nbviewer.jupyter.org/github/badenhh/Data-Science/blob/master/Basic Plotting/Basic Plotting.ipynb)


### PR DESCRIPTION
README had `####` in front of the main text, presumably to make it bold. This should be avoided.